### PR TITLE
Remove today's scramble from top

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,6 @@ export default async function Home() {
     <div>
       <p>hello {user ? user?.name : 'world'}</p>
       {user ? <LogoutButton /> : <LoginButton />}
-      <p>Todays Scramble: {todayScramble.scramble}</p>
       <Link href={`/scramble/${todayScramble.id}`}>Todays Scramble</Link>
     </div>
   )


### PR DESCRIPTION
## 関連するイシュー

## なぜやるか
スクランブルページに行く前にスクランブルが見えるのは違う

## やったこと
Topに本来必要ない表示を消した