### PR TITLE
Fix solution push bug

### DIFF
--- a/src/services/solution.ts
+++ b/src/services/solution.ts
@@ -43,14 +43,15 @@ export const makeSolution = async (
 
 const jadgeScore = (userSolution: string, scramble: string) => {
   const cube = new cubejs()
+  const normalizedSolution = cubeNotationNormalizer(userSolution)
+
   cube.move(scramble)
-  cube.move(userSolution)
+  cube.move(normalizedSolution)
 
   const isSolved = cube.isSolved()
   if (!isSolved) return null
 
-  const userSolutionCount =
-    cubeNotationNormalizer(userSolution).split(' ').length
+  const userSolutionCount = normalizedSolution.split(' ').length
   return userSolutionCount
 }
 


### PR DESCRIPTION
## 関連するイシュー

## なぜやるか
`UR` など、解釈できるがcube.moveではエラーになる表記がある場合にサービスが止まる状態になっていた

## やったこと
一旦`UR`→`U R`と置き換えて計算などするように書き換えたが、これでは本来許されないはず
しかしスコア計算ではこれを使っているため、扱いに迷う。
暫定的措置として、後で細かく見る： #68 